### PR TITLE
Dev composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=7.1",
     "contao/core-bundle": "^4.9",
-    "doctrine/dbal": "^2.12"
+    "doctrine/dbal": "^3.3"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": "^7.4 || ^8.0",
     "contao/core-bundle": "^4.9",
     "doctrine/dbal": "^3.3"
   },


### PR DESCRIPTION
Hallo Moritz,
ich habe mal in der composer.json die Abhängigkeiten geändert. Es scheint, als würde das dann funktionieren.
Spricht etwas gegen doctrine/dbal in Version 3.3 vorauszusetzen?